### PR TITLE
feat: replace deep merge data src with provider func

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,12 +1,12 @@
 plugin "terraform" {
   enabled = true
-  version = "0.6.0"
+  version = "0.13.0"
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
   preset  = "recommended"
 }
 
 plugin "aws" {
   enabled = true
-  version = "0.30.0"
+  version = "0.43.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,7 @@
-terraform 1.5.7
+terraform 1.12.2
 terraform-docs 0.20.0
-tflint 0.50.3
+tflint 0.59.1
 checkov 3.2.457
 awscli 2.27.62
 pre-commit 4.2.0
+golang 1.25.4

--- a/addon.tf
+++ b/addon.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 module "addon" {
-  source = "git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon?ref=v0.0.24"
+  source = "git::https://github.com/lablabs/terraform-aws-eks-universal-addon.git//modules/addon?ref=feat/data-source-inline"
 
   enabled = var.enabled
 
@@ -86,7 +86,8 @@ module "addon" {
   values   = one(data.utils_deep_merge_yaml.values[*].output)
 
   depends_on = [
-    local.addon_depends_on
+    local.addon_depends_on,
+    var.addon_depends_on
   ]
 }
 

--- a/variables-common.tf
+++ b/variables-common.tf
@@ -1,0 +1,14 @@
+# IMPORTANT: This file is synced with the "terraform-aws-eks-universal-addon" module. Any changes to this file might be overwritten upon the next release of that module.
+
+variable "enabled" {
+  type        = bool
+  default     = true
+  description = "Set to false to prevent the module from creating any resources."
+  nullable    = false
+}
+
+variable "addon_depends_on" {
+  type        = any
+  default     = []
+  description = "List of resources to wait for before installing the addon. Typically used to force a dependency on another addon."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,1 @@
-variable "enabled" {
-  type        = bool
-  default     = true
-  description = "Set to false to prevent the module from creating any resources."
-}
+# IMPORTANT: Add addon specific variables here

--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 # IMPORTANT: This file is synced with the "terraform-aws-eks-universal-addon" module. Any changes to this file might be overwritten upon the next release of that module.
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.8"
 
   required_providers {
     aws = {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

This change adds variable addon_depends_on to have more granular control over addon dependencies preventing Terraform plan to trigger change when data source changes.

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

Checked when addon_depends_on is used instead of depends_on if the Terraform plan stays the same when dependency changes.
  